### PR TITLE
Add OpenAPIStrict to Service Builder pattern

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -64,6 +64,12 @@ func (o openApiResponseValidatorService) Execute(ctx context.Context, request in
 	response interface{}, err error,
 ) {
 	response, err = o.next.Execute(ctx, request)
+	
+	// pass through strict errors without checking API conformity
+	if err != nil {
+		return response, err
+	}
+	
 	if j, ok2 := response.(kitDefaults.HttpCoder); ok2 {
 		if service.IsResponseValid(o.mappedResponses, response, j.StatusCode()) {
 			return response, err

--- a/response/response.go
+++ b/response/response.go
@@ -7,16 +7,22 @@ import (
 
 // BasicResponse
 //
-// When embedded into a Response object, this wil provide error handling functionality
+// When embedded into a Response object, this wil provide basic functionality
 type BasicResponse struct {
-	errString string
 	code      int
 }
 
+// ErrorResponse
+//
+// When embedded into a Response object, this wil provide error handling functionality
+type ErrorResponse struct {
+	errString string
+	BasicResponse
+}
 // Failed
 //
 // Implements kitDefaults.Failer
-func (b BasicResponse) Failed() error {
+func (b ErrorResponse) Failed() error {
 	if b.errString != "" {
 		return b
 	}
@@ -26,7 +32,7 @@ func (b BasicResponse) Failed() error {
 // NewError
 //
 // Use this function when it is necessary to indicate an error result for business logic
-func (b *BasicResponse) NewError(code int, format string, vars ...interface{}) {
+func (b *ErrorResponse) NewError(code int, format string, vars ...interface{}) {
 	b.code = code
 	b.errString = fmt.Sprintf(format, vars...)
 }
@@ -45,7 +51,7 @@ func (b BasicResponse) StatusCode() int {
 // Error
 //
 // Implements error interface
-func (b BasicResponse) Error() string {
+func (b ErrorResponse) Error() string {
 	return b.errString
 }
 

--- a/test/functional/apiGenerator/builder/builder_test.go
+++ b/test/functional/apiGenerator/builder/builder_test.go
@@ -1,0 +1,55 @@
+package builder
+
+import (
+	"testing"
+	
+	"github.com/yomiji/gkBoot/test/functional/apiGenerator/rest"
+)
+
+func TestServiceBuilder(t *testing.T) {
+	t.Run(
+		"OpenAPI Conforms to Result", func(subT *testing.T) {
+			var resp interface{}
+			var err error
+			func() {
+				resp, err = NewAmalgamationService().Execute(nil, &AmalgamationRequest{SpawnError: ""})
+				if err != nil {
+					subT.Fatalf("failed request: %s\n", err.Error())
+				}
+			}()
+			logicResponse := resp.(*AmalgamationResponse)
+			if logicResponse.Message != "Success" {
+				subT.Fatalf("failed, expected Success, got: %s", logicResponse.Message)
+			}
+		},
+	)
+	t.Run(
+		"OpenAPI Does not Conform", func(subT *testing.T) {
+			var err error
+			func() {
+				_, err = NewAmalgamationService().Execute(nil, &AmalgamationRequest{SpawnError: "failure"})
+				if err == nil {
+					subT.Fatalf("failed, expected api incompatible")
+				}
+			}()
+		},
+	)
+	t.Run(
+		"Conforms for correct error type", func(subT *testing.T) {
+			var err error
+			func() {
+				_, err = NewAmalgamationService().Execute(nil, &AmalgamationRequest{SpawnError: "error"})
+				if err == nil {
+					subT.Fatalf("failed request, should return error")
+				}
+			}()
+			logicResponse := err.(*rest.ErrorResponse)
+			if logicResponse.Message != "Fail" {
+				subT.Fatalf("failed, expected Fail, got: %s", logicResponse.Message)
+			}
+			if logicResponse.Code != 411 {
+				subT.Fatalf("failed, expected 411, got: %d", logicResponse.Code)
+			}
+		},
+	)
+}

--- a/test/functional/apiGenerator/builder/service_builder.go
+++ b/test/functional/apiGenerator/builder/service_builder.go
@@ -1,0 +1,73 @@
+package builder
+
+import (
+	"context"
+	
+	"github.com/yomiji/gkBoot"
+	"github.com/yomiji/gkBoot/config"
+	"github.com/yomiji/gkBoot/request"
+	"github.com/yomiji/gkBoot/service"
+	"github.com/yomiji/gkBoot/test/functional/apiGenerator/rest"
+)
+
+type AmalgamationRequest struct {
+	SpawnError string `query:"error"`
+}
+
+func (a AmalgamationRequest) Info() request.HttpRouteInfo {
+	return request.HttpRouteInfo{
+		Name:        "AmalgamationRequest",
+		Method:      "GET",
+		Path:        "/mixin",
+		Description: "An amalgamation service",
+	}
+}
+
+type AmalgamationResponse struct {
+	Message string `json:"message"`
+}
+
+func (a AmalgamationResponse) StatusCode() int {
+	return 201
+}
+
+type AmalgamationService struct{}
+
+func (a AmalgamationService) ExpectedResponses() service.MappedResponses {
+	return service.RegisterResponses(
+		service.ResponseTypes{
+			{
+				Type: new(AmalgamationResponse),
+				Code: 201,
+			},
+			{
+				Type: new(rest.ErrorResponse),
+				Code: 411,
+			},
+		},
+	)
+}
+
+func (a AmalgamationService) Execute(_ context.Context, req interface{}) (interface{}, error) {
+	r := req.(*AmalgamationRequest)
+	if r.SpawnError != "" {
+		if r.SpawnError != "error" {
+			return struct {
+				Errorable bool
+			}{Errorable: true}, nil
+		} else {
+			errType := &rest.ErrorResponse{
+				Message: "Fail",
+				Code:    411,
+			}
+			return nil, errType
+		}
+	}
+	
+	resp := &AmalgamationResponse{Message: "Success"}
+	return resp, nil
+}
+
+func NewAmalgamationService() service.Service {
+	return gkBoot.NewServiceBuilder(new(AmalgamationService), config.WithStrictAPI()).MixinLogging().Build()
+}


### PR DESCRIPTION
resolves #11 Add OpenAPIStrict to Service Builder pattern

fix issue with err status code not used on raw error results

fix allow hard errors to pass through strict OpenAPI without checking

fix BasicResponse by removing error logic and separate into ErrorResponse