### PR TITLE
chore(fix-client): response was closed before returning to caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ In gkBoot, I tried to capture much of that while still maintaining that
 which makes Go great. Hopefully you like it too.
 
 ## Installation
-*Note: Please use go 1.18 for installation*
+*Note: Please use go 1.24 for installation*
 ```bash
-go get github.com/yomiji/gkBoot@v1.0.0
+go get github.com/yomiji/gkBoot@v1.6.0
 ```
 
 ## Use

--- a/client.go
+++ b/client.go
@@ -204,11 +204,29 @@ func DoGeneratedRequest[ResponseType any](
 		return err
 	}
 
-	defer resp.Body.Close()
-
 	var temp interface{} = responseObj
 
+	if statusCoder, ok := temp.(response.CodedResponse); ok {
+		statusCoder.NewCode(resp.StatusCode)
+	}
+
+	if captureReader, ok := temp.(response.CaptureReader); ok {
+		err = captureReader.Capture(resp.Body)
+		if err != nil {
+			return fmt.Errorf("unable to capture response body for %s %s due to %s", r.Method, r.URL, err)
+		}
+
+		return nil
+	}
+
+	defer resp.Body.Close()
+
 	var body []byte
+
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("unable to parse response body for %s %s due to %s", r.Method, r.URL, err)
+	}
 
 	// if the response object is nil, only non-200 indicates error
 	if responseObj == nil {
@@ -222,24 +240,6 @@ func DoGeneratedRequest[ResponseType any](
 		}
 
 		return nil
-	}
-
-	if statusCoder, ok := temp.(response.CodedResponse); ok {
-		statusCoder.NewCode(resp.StatusCode)
-	}
-
-	if captureReader, ok := temp.(response.CaptureReader); ok {
-		err = captureReader.Capture(resp.Body)
-		if err != nil {
-			return fmt.Errorf("unable to capture response body for %s %s due to %s", r.Method, r.URL, err)
-		}
-
-		return nil
-	} else {
-		body, err = io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("unable to parse response body for %s %s due to %s", r.Method, r.URL, err)
-		}
 	}
 
 	if erredResponse, ok := temp.(response.ErredResponse); ok {


### PR DESCRIPTION
- Small update to the readme
- Move Capture Reader to prevent body closing before utilization.
